### PR TITLE
fix(design): unify page headers and typography hierarchy

### DIFF
--- a/packages/web/src/app/(dashboard)/cli/connect/page.tsx
+++ b/packages/web/src/app/(dashboard)/cli/connect/page.tsx
@@ -233,7 +233,7 @@ function CliConnectContent() {
 function Header() {
   return (
     <div>
-      <h1 className="text-2xl font-semibold tracking-tight">Connect CLI</h1>
+      <h1 className="text-2xl md:text-3xl font-semibold font-display tracking-tight">Connect CLI</h1>
       <p className="text-sm text-muted-foreground">Link your Otter CLI to this dashboard</p>
     </div>
   );

--- a/packages/web/src/app/(dashboard)/cli/connect/page.tsx
+++ b/packages/web/src/app/(dashboard)/cli/connect/page.tsx
@@ -233,7 +233,9 @@ function CliConnectContent() {
 function Header() {
   return (
     <div>
-      <h1 className="text-2xl md:text-3xl font-semibold font-display tracking-tight">Connect CLI</h1>
+      <h1 className="text-2xl md:text-3xl font-semibold font-display tracking-tight">
+        Connect CLI
+      </h1>
       <p className="text-sm text-muted-foreground">Link your Otter CLI to this dashboard</p>
     </div>
   );

--- a/packages/web/src/app/(dashboard)/settings/page.tsx
+++ b/packages/web/src/app/(dashboard)/settings/page.tsx
@@ -430,7 +430,9 @@ export default function SettingsPage() {
 
       {/* Danger Zone */}
       <section className="space-y-4">
-        <h2 className="text-xs font-medium uppercase tracking-wider text-destructive">Danger Zone</h2>
+        <h2 className="text-xs font-medium uppercase tracking-wider text-destructive">
+          Danger Zone
+        </h2>
         <div className="rounded-xl border border-destructive/20 p-5">
           <div className="flex items-center justify-between">
             <div>

--- a/packages/web/src/app/(dashboard)/settings/page.tsx
+++ b/packages/web/src/app/(dashboard)/settings/page.tsx
@@ -290,7 +290,7 @@ export default function SettingsPage() {
       {/* Header */}
       <div>
         <h1 className="text-2xl md:text-3xl font-semibold font-display tracking-tight">Settings</h1>
-        <p className="text-sm text-muted-foreground">Manage your account and webhook tokens</p>
+        <p className="text-sm text-muted-foreground mt-1">Manage your account and webhook tokens</p>
       </div>
 
       {/* Account Section */}

--- a/packages/web/src/app/(dashboard)/settings/page.tsx
+++ b/packages/web/src/app/(dashboard)/settings/page.tsx
@@ -295,7 +295,7 @@ export default function SettingsPage() {
 
       {/* Account Section */}
       <section className="space-y-4">
-        <h2 className="text-sm font-medium text-foreground flex items-center gap-2">
+        <h2 className="text-xs font-medium uppercase tracking-wider text-muted-foreground flex items-center gap-2">
           <User className="h-4 w-4" strokeWidth={1.5} />
           Account
         </h2>
@@ -327,7 +327,7 @@ export default function SettingsPage() {
       {/* Webhooks Section */}
       <section className="space-y-4">
         <div className="flex items-center justify-between">
-          <h2 className="text-sm font-medium text-foreground flex items-center gap-2">
+          <h2 className="text-xs font-medium uppercase tracking-wider text-muted-foreground flex items-center gap-2">
             <Webhook className="h-4 w-4" strokeWidth={1.5} />
             Webhook Tokens
           </h2>
@@ -430,7 +430,7 @@ export default function SettingsPage() {
 
       {/* Danger Zone */}
       <section className="space-y-4">
-        <h2 className="text-sm font-medium text-destructive">Danger Zone</h2>
+        <h2 className="text-xs font-medium uppercase tracking-wider text-destructive">Danger Zone</h2>
         <div className="rounded-xl border border-destructive/20 p-5">
           <div className="flex items-center justify-between">
             <div>

--- a/packages/web/src/app/(dashboard)/settings/page.tsx
+++ b/packages/web/src/app/(dashboard)/settings/page.tsx
@@ -289,7 +289,7 @@ export default function SettingsPage() {
     <div className="max-w-3xl space-y-8">
       {/* Header */}
       <div>
-        <h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
+        <h1 className="text-2xl md:text-3xl font-semibold font-display tracking-tight">Settings</h1>
         <p className="text-sm text-muted-foreground">Manage your account and webhook tokens</p>
       </div>
 

--- a/packages/web/src/app/(dashboard)/snapshots/[id]/page.tsx
+++ b/packages/web/src/app/(dashboard)/snapshots/[id]/page.tsx
@@ -133,7 +133,7 @@ export default function SnapshotDetailPage({ params }: { params: Promise<{ id: s
       {/* Header */}
       <div>
         <div className="flex items-center gap-3">
-          <h1 className="text-2xl font-semibold tracking-tight">
+          <h1 className="text-2xl md:text-3xl font-semibold font-display tracking-tight">
             Snapshot <code className="font-mono text-lg">{id.slice(0, 8)}</code>
           </h1>
         </div>

--- a/packages/web/src/app/(dashboard)/snapshots/page.tsx
+++ b/packages/web/src/app/(dashboard)/snapshots/page.tsx
@@ -204,7 +204,7 @@ export default function SnapshotsPage() {
       {/* Header */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h1 className="text-2xl font-semibold tracking-tight">Snapshots</h1>
+          <h1 className="text-2xl md:text-3xl font-semibold font-display tracking-tight">Snapshots</h1>
           <p className="text-sm text-muted-foreground">Browse all dev environment backups</p>
         </div>
         <div className="relative w-full sm:w-64">

--- a/packages/web/src/app/(dashboard)/snapshots/page.tsx
+++ b/packages/web/src/app/(dashboard)/snapshots/page.tsx
@@ -204,7 +204,9 @@ export default function SnapshotsPage() {
       {/* Header */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h1 className="text-2xl md:text-3xl font-semibold font-display tracking-tight">Snapshots</h1>
+          <h1 className="text-2xl md:text-3xl font-semibold font-display tracking-tight">
+            Snapshots
+          </h1>
           <p className="text-sm text-muted-foreground">Browse all dev environment backups</p>
         </div>
         <div className="relative w-full sm:w-64">


### PR DESCRIPTION
## Summary
统一所有 Dashboard 页面的标题排版：

- 所有 H1 统一使用 `font-display` + 响应式 `text-2xl md:text-3xl`
- 统一 subtitle 间距 `mt-1`
- Settings section headers 改为与 DashboardSegment 一致的 `text-xs uppercase tracking-wider` 风格

## Changes
- 4 pages: H1 heading standardization
- Settings subtitle spacing fix
- Settings section header style unification

Closes #2
