### PR TITLE
fix(design): standardize all tables to use Table UI component

### DIFF
--- a/packages/web/src/app/(dashboard)/page.tsx
+++ b/packages/web/src/app/(dashboard)/page.tsx
@@ -17,7 +17,14 @@ import { AreaChart, type AreaChartDataPoint } from "@/components/charts";
 import { DashboardSegment } from "@/components/dashboard/dashboard-segment";
 import { StatCard, StatGrid } from "@/components/dashboard/stat-card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import { formatSize, formatTimeAgo } from "@/lib/utils";
 
 // ---------------------------------------------------------------------------

--- a/packages/web/src/app/(dashboard)/page.tsx
+++ b/packages/web/src/app/(dashboard)/page.tsx
@@ -17,6 +17,7 @@ import { AreaChart, type AreaChartDataPoint } from "@/components/charts";
 import { DashboardSegment } from "@/components/dashboard/dashboard-segment";
 import { StatCard, StatGrid } from "@/components/dashboard/stat-card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { formatSize, formatTimeAgo } from "@/lib/utils";
 
 // ---------------------------------------------------------------------------
@@ -298,37 +299,37 @@ export default function DashboardPage() {
                   </div>
                 ) : (
                   <div className="overflow-x-auto">
-                    <table className="w-full text-sm" aria-label="Recent snapshots">
-                      <thead>
-                        <tr className="border-b border-border text-left">
-                          <th className="pb-2 pr-4 font-medium text-muted-foreground text-xs">
+                    <Table aria-label="Recent snapshots">
+                      <TableHeader>
+                        <TableRow className="border-b border-border">
+                          <TableHead className="font-medium text-muted-foreground text-xs">
                             Host
-                          </th>
-                          <th className="pb-2 pr-4 font-medium text-muted-foreground text-xs">
+                          </TableHead>
+                          <TableHead className="font-medium text-muted-foreground text-xs">
                             Platform
-                          </th>
-                          <th className="pb-2 pr-4 font-medium text-muted-foreground text-xs text-right">
+                          </TableHead>
+                          <TableHead className="font-medium text-muted-foreground text-xs text-right">
                             Files
-                          </th>
-                          <th className="pb-2 pr-4 font-medium text-muted-foreground text-xs text-right">
+                          </TableHead>
+                          <TableHead className="font-medium text-muted-foreground text-xs text-right">
                             Lists
-                          </th>
-                          <th className="pb-2 pr-4 font-medium text-muted-foreground text-xs text-right">
+                          </TableHead>
+                          <TableHead className="font-medium text-muted-foreground text-xs text-right">
                             Size
-                          </th>
-                          <th className="pb-2 font-medium text-muted-foreground text-xs text-right">
+                          </TableHead>
+                          <TableHead className="font-medium text-muted-foreground text-xs text-right">
                             When
-                          </th>
-                        </tr>
-                      </thead>
-                      <tbody>
+                          </TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
                         {data?.snapshots.map((snap) => (
-                          <tr
+                          <TableRow
                             key={snap.id}
-                            className="group border-b border-border/50 last:border-0 hover:bg-accent/50 focus-within:bg-accent/50 transition-colors cursor-pointer"
+                            className="group border-b border-border/50 last:border-0 hover:bg-accent/50 focus-within:bg-accent/50 cursor-pointer"
                             onClick={() => router.push(`/snapshots/${snap.id}`)}
                           >
-                            <td className="py-2.5 pr-4">
+                            <TableCell>
                               <Link
                                 href={`/snapshots/${snap.id}`}
                                 className="flex items-center gap-2 group-hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded transition-colors"
@@ -342,20 +343,20 @@ export default function DashboardPage() {
                                 />
                                 <span className="font-medium">{snap.hostname}</span>
                               </Link>
-                            </td>
-                            <td className="py-2.5 pr-4 text-muted-foreground">
+                            </TableCell>
+                            <TableCell className="text-muted-foreground">
                               {snap.platform}/{snap.arch}
-                            </td>
-                            <td className="py-2.5 pr-4 text-right tabular-nums">
+                            </TableCell>
+                            <TableCell className="text-right tabular-nums">
                               {snap.fileCount}
-                            </td>
-                            <td className="py-2.5 pr-4 text-right tabular-nums">
+                            </TableCell>
+                            <TableCell className="text-right tabular-nums">
                               {snap.listCount}
-                            </td>
-                            <td className="py-2.5 pr-4 text-right tabular-nums text-muted-foreground">
+                            </TableCell>
+                            <TableCell className="text-right tabular-nums text-muted-foreground">
                               {formatSize(snap.sizeBytes)}
-                            </td>
-                            <td className="py-2.5 text-right">
+                            </TableCell>
+                            <TableCell className="text-right">
                               <div className="flex items-center justify-end gap-2">
                                 <span className="text-muted-foreground text-xs">
                                   {formatTimeAgo(snap.snapshotAt)}
@@ -365,11 +366,11 @@ export default function DashboardPage() {
                                   strokeWidth={1.5}
                                 />
                               </div>
-                            </td>
-                          </tr>
+                            </TableCell>
+                          </TableRow>
                         ))}
-                      </tbody>
-                    </table>
+                      </TableBody>
+                    </Table>
                   </div>
                 )}
               </div>

--- a/packages/web/src/app/(dashboard)/snapshots/page.tsx
+++ b/packages/web/src/app/(dashboard)/snapshots/page.tsx
@@ -8,7 +8,14 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import { formatDateTime, formatSize, formatTimeAgo } from "@/lib/utils";
 
 // ---------------------------------------------------------------------------
@@ -313,7 +320,9 @@ export default function SnapshotsPage() {
                           {snap.platform}/{snap.arch}
                         </Badge>
                       </TableCell>
-                      <TableCell className="text-right tabular-nums">{snap.collectorCount}</TableCell>
+                      <TableCell className="text-right tabular-nums">
+                        {snap.collectorCount}
+                      </TableCell>
                       <TableCell className="text-right tabular-nums">{snap.fileCount}</TableCell>
                       <TableCell className="text-right tabular-nums">{snap.listCount}</TableCell>
                       <TableCell className="text-right tabular-nums text-muted-foreground">

--- a/packages/web/src/app/(dashboard)/snapshots/page.tsx
+++ b/packages/web/src/app/(dashboard)/snapshots/page.tsx
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { formatDateTime, formatSize, formatTimeAgo } from "@/lib/utils";
 
 // ---------------------------------------------------------------------------
@@ -247,43 +248,43 @@ export default function SnapshotsPage() {
           {/* Table */}
           <div className="rounded-xl bg-secondary p-1">
             <div className="overflow-x-auto">
-              <table className="w-full text-sm" aria-label="Snapshots list">
-                <thead>
-                  <tr className="border-b border-border">
-                    <th className="px-4 py-3 text-left font-medium text-muted-foreground text-xs">
+              <Table aria-label="Snapshots list">
+                <TableHeader>
+                  <TableRow className="border-b border-border">
+                    <TableHead className="font-medium text-muted-foreground text-xs">
                       Snapshot
-                    </th>
-                    <th className="px-4 py-3 text-left font-medium text-muted-foreground text-xs">
+                    </TableHead>
+                    <TableHead className="font-medium text-muted-foreground text-xs">
                       Host
-                    </th>
-                    <th className="px-4 py-3 text-left font-medium text-muted-foreground text-xs">
+                    </TableHead>
+                    <TableHead className="font-medium text-muted-foreground text-xs">
                       Platform
-                    </th>
-                    <th className="px-4 py-3 text-right font-medium text-muted-foreground text-xs">
+                    </TableHead>
+                    <TableHead className="font-medium text-muted-foreground text-xs text-right">
                       Collectors
-                    </th>
-                    <th className="px-4 py-3 text-right font-medium text-muted-foreground text-xs">
+                    </TableHead>
+                    <TableHead className="font-medium text-muted-foreground text-xs text-right">
                       Files
-                    </th>
-                    <th className="px-4 py-3 text-right font-medium text-muted-foreground text-xs">
+                    </TableHead>
+                    <TableHead className="font-medium text-muted-foreground text-xs text-right">
                       Lists
-                    </th>
-                    <th className="px-4 py-3 text-right font-medium text-muted-foreground text-xs">
+                    </TableHead>
+                    <TableHead className="font-medium text-muted-foreground text-xs text-right">
                       Size
-                    </th>
-                    <th className="px-4 py-3 text-right font-medium text-muted-foreground text-xs">
+                    </TableHead>
+                    <TableHead className="font-medium text-muted-foreground text-xs text-right">
                       Created
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
                   {snapshots.map((snap) => (
-                    <tr
+                    <TableRow
                       key={snap.id}
-                      className="group border-b border-border/50 last:border-0 hover:bg-accent/50 focus-within:bg-accent/50 transition-colors cursor-pointer"
+                      className="group border-b border-border/50 last:border-0 hover:bg-accent/50 focus-within:bg-accent/50 cursor-pointer"
                       onClick={() => router.push(`/snapshots/${snap.id}`)}
                     >
-                      <td className="px-4 py-3">
+                      <TableCell>
                         <Link
                           href={`/snapshots/${snap.id}`}
                           className="inline-flex items-center gap-2 text-foreground group-hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded transition-colors"
@@ -297,8 +298,8 @@ export default function SnapshotsPage() {
                           />
                           <code className="text-xs font-mono">{snap.id.slice(0, 8)}</code>
                         </Link>
-                      </td>
-                      <td className="px-4 py-3">
+                      </TableCell>
+                      <TableCell>
                         <div className="flex items-center gap-2">
                           <Monitor
                             className="h-3.5 w-3.5 text-muted-foreground"
@@ -306,19 +307,19 @@ export default function SnapshotsPage() {
                           />
                           <span className="font-medium">{snap.hostname}</span>
                         </div>
-                      </td>
-                      <td className="px-4 py-3">
+                      </TableCell>
+                      <TableCell>
                         <Badge variant="secondary" className="text-xs font-normal">
                           {snap.platform}/{snap.arch}
                         </Badge>
-                      </td>
-                      <td className="px-4 py-3 text-right tabular-nums">{snap.collectorCount}</td>
-                      <td className="px-4 py-3 text-right tabular-nums">{snap.fileCount}</td>
-                      <td className="px-4 py-3 text-right tabular-nums">{snap.listCount}</td>
-                      <td className="px-4 py-3 text-right tabular-nums text-muted-foreground">
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums">{snap.collectorCount}</TableCell>
+                      <TableCell className="text-right tabular-nums">{snap.fileCount}</TableCell>
+                      <TableCell className="text-right tabular-nums">{snap.listCount}</TableCell>
+                      <TableCell className="text-right tabular-nums text-muted-foreground">
                         {formatSize(snap.sizeBytes)}
-                      </td>
-                      <td className="px-4 py-3 text-right">
+                      </TableCell>
+                      <TableCell className="text-right">
                         <div className="flex items-center justify-end gap-2">
                           <div className="flex flex-col items-end">
                             <span className="text-xs text-muted-foreground">
@@ -333,11 +334,11 @@ export default function SnapshotsPage() {
                             strokeWidth={1.5}
                           />
                         </div>
-                      </td>
-                    </tr>
+                      </TableCell>
+                    </TableRow>
                   ))}
-                </tbody>
-              </table>
+                </TableBody>
+              </Table>
             </div>
           </div>
 

--- a/packages/web/src/components/ui/table.tsx
+++ b/packages/web/src/components/ui/table.tsx
@@ -58,7 +58,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "h-10 px-4 py-3 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className,
       )}
       {...props}
@@ -71,7 +71,7 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
     <td
       data-slot="table-cell"
       className={cn(
-        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "px-4 py-3 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
将所有手写 `<table>` 迁移到 Table UI 组件，统一 padding 和交互样式：

- Table UI 组件 padding 调整为 `px-4 py-3`
- Dashboard page 表格迁移到 Table 组件
- Snapshots page 表格迁移到 Table 组件
- 统一 hover 效果和 border 处理

## Changes
- `components/ui/table.tsx`: padding standardization
- `app/(dashboard)/page.tsx`: migrate hand-rolled table
- `app/(dashboard)/snapshots/page.tsx`: migrate hand-rolled table

Closes #3
