### PR TITLE
fix(design): standardize layout spacing and border-radius

### DIFF
--- a/packages/web/src/app/(dashboard)/settings/page.tsx
+++ b/packages/web/src/app/(dashboard)/settings/page.tsx
@@ -95,7 +95,7 @@ function WebhookRow({
   const fullUrl = `${baseUrl}/api/webhook/${webhook.token}`;
 
   return (
-    <div className="rounded-xl bg-secondary p-4 space-y-3">
+    <div className="rounded-[var(--radius-card)] bg-secondary p-4 space-y-3">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2.5">
           <Webhook className="h-4 w-4 text-primary" strokeWidth={1.5} />
@@ -150,7 +150,7 @@ function WebhooksSkeleton() {
     <div className="space-y-3">
       {Array.from({ length: 2 }).map((_, i) => (
         // biome-ignore lint/suspicious/noArrayIndexKey: skeleton cards are static, never reorder
-        <div key={`webhook-skeleton-${i}`} className="rounded-xl bg-secondary p-4 space-y-3">
+        <div key={`webhook-skeleton-${i}`} className="rounded-[var(--radius-card)] bg-secondary p-4 space-y-3">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2.5">
               <Skeleton className="h-4 w-4" />
@@ -299,7 +299,7 @@ export default function SettingsPage() {
           <User className="h-4 w-4" strokeWidth={1.5} />
           Account
         </h2>
-        <div className="rounded-xl bg-secondary p-5">
+        <div className="rounded-[var(--radius-card)] bg-secondary p-5">
           <div className="flex items-center gap-4">
             <Avatar className="h-14 w-14">
               {userImage && <AvatarImage src={userImage} alt={userName} />}
@@ -387,7 +387,7 @@ export default function SettingsPage() {
         {loading ? (
           <WebhooksSkeleton />
         ) : error ? (
-          <div className="rounded-xl bg-secondary p-8 text-center">
+          <div className="rounded-[var(--radius-card)] bg-secondary p-8 text-center">
             <p className="text-sm text-destructive">{error}</p>
             <Button
               variant="ghost"
@@ -402,7 +402,7 @@ export default function SettingsPage() {
             </Button>
           </div>
         ) : webhooks.length === 0 ? (
-          <div className="rounded-xl bg-secondary p-8 text-center">
+          <div className="rounded-[var(--radius-card)] bg-secondary p-8 text-center">
             <Webhook className="h-8 w-8 text-muted-foreground/40 mx-auto" strokeWidth={1.5} />
             <p className="mt-3 text-sm text-muted-foreground">No webhook tokens yet</p>
             <p className="mt-1 text-xs text-muted-foreground/60">
@@ -433,7 +433,7 @@ export default function SettingsPage() {
         <h2 className="text-xs font-medium uppercase tracking-wider text-destructive">
           Danger Zone
         </h2>
-        <div className="rounded-xl border border-destructive/20 p-5">
+        <div className="rounded-[var(--radius-card)] border border-destructive/20 p-5">
           <div className="flex items-center justify-between">
             <div>
               <p className="text-sm font-medium text-foreground">Delete all snapshots</p>

--- a/packages/web/src/app/(dashboard)/settings/page.tsx
+++ b/packages/web/src/app/(dashboard)/settings/page.tsx
@@ -149,8 +149,11 @@ function WebhooksSkeleton() {
   return (
     <div className="space-y-3">
       {Array.from({ length: 2 }).map((_, i) => (
-        // biome-ignore lint/suspicious/noArrayIndexKey: skeleton cards are static, never reorder
-        <div key={`webhook-skeleton-${i}`} className="rounded-[var(--radius-card)] bg-secondary p-4 space-y-3">
+        <div
+          // biome-ignore lint/suspicious/noArrayIndexKey: skeleton cards are static, never reorder
+          key={`webhook-skeleton-${i}`}
+          className="rounded-[var(--radius-card)] bg-secondary p-4 space-y-3"
+        >
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2.5">
               <Skeleton className="h-4 w-4" />

--- a/packages/web/src/app/(dashboard)/settings/page.tsx
+++ b/packages/web/src/app/(dashboard)/settings/page.tsx
@@ -286,7 +286,7 @@ export default function SettingsPage() {
   const userInitial = userName[0] ?? "?";
 
   return (
-    <div className="max-w-3xl space-y-8">
+    <div className="max-w-3xl space-y-4 md:space-y-6">
       {/* Header */}
       <div>
         <h1 className="text-2xl md:text-3xl font-semibold font-display tracking-tight">Settings</h1>

--- a/packages/web/src/app/(dashboard)/snapshots/[id]/_components/collector-card.tsx
+++ b/packages/web/src/app/(dashboard)/snapshots/[id]/_components/collector-card.tsx
@@ -43,7 +43,7 @@ export function CollectorCard({ collector }: { collector: Collector }) {
   }, [isApps, collector.lists, totalLists]);
 
   return (
-    <Card className="gap-0 py-0 overflow-hidden">
+    <Card className="overflow-hidden">
       {/* Header */}
       <CardHeader className="gap-0 px-5 py-4 border-b border-border/40">
         <div className="flex items-center justify-between">

--- a/packages/web/src/app/(dashboard)/snapshots/[id]/_components/export-section.tsx
+++ b/packages/web/src/app/(dashboard)/snapshots/[id]/_components/export-section.tsx
@@ -24,7 +24,7 @@ export function ExportSection({ data, snapshotId }: ExportSectionProps) {
   };
 
   return (
-    <Card className="py-0">
+    <Card>
       <CardContent className="px-5 py-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">

--- a/packages/web/src/app/(dashboard)/snapshots/page.tsx
+++ b/packages/web/src/app/(dashboard)/snapshots/page.tsx
@@ -59,7 +59,7 @@ function SnapshotsPageSkeleton() {
       </div>
 
       {/* Table skeleton */}
-      <div className="rounded-xl bg-secondary p-1">
+      <div className="rounded-[var(--radius-card)] bg-secondary p-1">
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
@@ -230,7 +230,7 @@ export default function SnapshotsPage() {
       {loading ? (
         <SnapshotsPageSkeleton />
       ) : error ? (
-        <div className="rounded-xl bg-secondary p-12 text-center">
+        <div className="rounded-[var(--radius-card)] bg-secondary p-12 text-center">
           <p className="text-sm text-destructive">{error}</p>
           <Button
             variant="link"
@@ -245,7 +245,7 @@ export default function SnapshotsPage() {
           </Button>
         </div>
       ) : snapshots.length === 0 ? (
-        <div className="rounded-xl bg-secondary p-12 text-center">
+        <div className="rounded-[var(--radius-card)] bg-secondary p-12 text-center">
           <Archive className="h-8 w-8 text-muted-foreground/40 mx-auto" strokeWidth={1.5} />
           <p className="mt-3 text-sm text-muted-foreground">No snapshots yet</p>
           <p className="mt-1 text-xs text-muted-foreground/60">
@@ -255,7 +255,7 @@ export default function SnapshotsPage() {
       ) : (
         <>
           {/* Table */}
-          <div className="rounded-xl bg-secondary p-1">
+          <div className="rounded-[var(--radius-card)] bg-secondary p-1">
             <div className="overflow-x-auto">
               <Table aria-label="Snapshots list">
                 <TableHeader>

--- a/packages/web/src/app/(dashboard)/snapshots/page.tsx
+++ b/packages/web/src/app/(dashboard)/snapshots/page.tsx
@@ -48,7 +48,7 @@ const PAGE_SIZE = 20;
 
 function SnapshotsPageSkeleton() {
   return (
-    <div className="space-y-6">
+    <div className="space-y-4 md:space-y-6">
       {/* Header skeleton */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
@@ -208,7 +208,7 @@ export default function SnapshotsPage() {
   };
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4 md:space-y-6">
       {/* Header */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>

--- a/packages/web/src/components/layout/app-shell.tsx
+++ b/packages/web/src/components/layout/app-shell.tsx
@@ -119,11 +119,9 @@ function AppShellInner({ children }: AppShellProps) {
           </div>
         </header>
 
-        {/* Floating island content area */}
-        <div className="flex-1 px-2 pb-2 md:px-3 md:pb-3">
-          <div className="h-full rounded-[16px] md:rounded-[20px] bg-card p-3 md:p-5 overflow-y-auto">
-            {children}
-          </div>
+        {/* Content area */}
+        <div className="flex-1 p-4 md:p-5 overflow-y-auto">
+          {children}
         </div>
       </main>
     </div>

--- a/packages/web/src/components/layout/app-shell.tsx
+++ b/packages/web/src/components/layout/app-shell.tsx
@@ -120,9 +120,7 @@ function AppShellInner({ children }: AppShellProps) {
         </header>
 
         {/* Content area */}
-        <div className="flex-1 p-4 md:p-5 overflow-y-auto">
-          {children}
-        </div>
+        <div className="flex-1 p-4 md:p-5 overflow-y-auto">{children}</div>
       </main>
     </div>
   );

--- a/packages/web/src/components/ui/card.tsx
+++ b/packages/web/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "flex flex-col gap-6 rounded-xl bg-secondary py-6 text-card-foreground",
+        "flex flex-col gap-0 rounded-xl bg-secondary py-0 text-card-foreground",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
标准化整个 Dashboard 的间距和圆角系统：

- Card 默认值 `py-6 gap-6` → `py-0 gap-0`（匹配所有实际使用）
- 容器圆角统一为 `rounded-[var(--radius-card)]`
- App-shell 内容 padding 简化为 `p-4 md:p-5`
- 页面级 space-y 统一为 `space-y-4 md:space-y-6`
- 移除所有冗余的 Card 覆盖

## Changes
- `components/ui/card.tsx`: fix defaults
- `components/layout/app-shell.tsx`: simplify padding
- 4 pages: spacing and radius unification

Closes #4
