### PR TITLE
fix(design): unify snapshot row alignment and consistency

### DIFF
--- a/packages/web/src/app/(dashboard)/snapshots/[id]/_components/file-row.tsx
+++ b/packages/web/src/app/(dashboard)/snapshots/[id]/_components/file-row.tsx
@@ -23,7 +23,7 @@ export function FileRow({ file }: { file: FileData }) {
   return (
     <>
       <div className="flex items-center gap-3 rounded-lg border border-border/50 bg-card px-3 py-2.5">
-        <FileText className="h-3.5 w-3.5 text-muted-foreground shrink-0" strokeWidth={1.5} />
+        <FileText className="h-4 w-4 text-muted-foreground shrink-0" strokeWidth={1.5} />
         <code className="text-xs font-mono text-foreground truncate flex-1" title={file.path}>
           {filename}
         </code>

--- a/packages/web/src/app/(dashboard)/snapshots/[id]/_components/list-item-row.tsx
+++ b/packages/web/src/app/(dashboard)/snapshots/[id]/_components/list-item-row.tsx
@@ -18,7 +18,7 @@ export function ListItemRow({ item, iconUrl, isSshKey }: ListItemRowProps) {
   const [iconError, setIconError] = useState(false);
 
   return (
-    <div className="flex items-center gap-2.5 rounded-lg border border-border/50 bg-card px-3 py-2.5">
+    <div className="flex items-start gap-3 rounded-lg border border-border/50 bg-card px-3 py-2.5">
       {isSshKey ? (
         <CircleCheck className="h-4 w-4 text-success shrink-0" strokeWidth={1.5} />
       ) : iconUrl && !iconError ? (
@@ -53,7 +53,7 @@ export function ListItemRow({ item, iconUrl, isSshKey }: ListItemRowProps) {
         )}
       </div>
       {item.version && (
-        <code className="text-2xs text-muted-foreground font-mono shrink-0">{item.version}</code>
+        <code className="text-2xs text-muted-foreground font-mono shrink-0 mt-0.5">{item.version}</code>
       )}
     </div>
   );

--- a/packages/web/src/app/(dashboard)/snapshots/[id]/_components/list-item-row.tsx
+++ b/packages/web/src/app/(dashboard)/snapshots/[id]/_components/list-item-row.tsx
@@ -53,7 +53,9 @@ export function ListItemRow({ item, iconUrl, isSshKey }: ListItemRowProps) {
         )}
       </div>
       {item.version && (
-        <code className="text-2xs text-muted-foreground font-mono shrink-0 mt-0.5">{item.version}</code>
+        <code className="text-2xs text-muted-foreground font-mono shrink-0 mt-0.5">
+          {item.version}
+        </code>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
统一 FileRow 和 ListItemRow 的对齐和尺寸：

- ListItemRow gap `2.5` → `3`（与 FileRow 一致）
- FileRow icon `h-3.5 w-3.5` → `h-4 w-4`（与 ListItemRow 一致）
- ListItemRow 改 `items-start` + version 加 `mt-0.5`（与 name baseline 对齐）

Closes #15
