### PR TITLE
ci: enable L2 API E2E tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,5 +15,6 @@ jobs:
       typecheck-command: "bun run lint"
       lint-command: "bun run lint:biome"
       osv-config: "osv-scanner.toml"
-      enable-l2: "false"
+      enable-l2: "true"
+      l2-command: "bun run test:e2e"
     secrets: inherit


### PR DESCRIPTION
Enable L2 integration/API E2E tests in CI.\n\n- Set enable-l2 to true\n- Configure l2-command