### PR TITLE
fix(sidebar): correct collapsed logo padding per B02-2c

### DIFF
--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -43,7 +43,7 @@ export function Sidebar() {
       >
         {collapsed ? (
           <div className="flex h-screen w-[68px] flex-col items-center">
-            <div className="flex h-14 w-full items-center justify-start pl-5 pr-3">
+            <div className="flex h-14 w-full items-center justify-start pl-6 pr-3">
               <img src="/logo-24.png" alt="Otter" width={24} height={24} className="shrink-0" />
             </div>
 


### PR DESCRIPTION
收起态 sidebar logo padding 修正为 `pl-6` (24px)，符合 B02-2c 规范。

Closes #24
