### PR TITLE
fix(ci): resolve hono override conflict + use bunx for wrangler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest

--- a/bun.lock
+++ b/bun.lock
@@ -97,7 +97,7 @@
     },
   },
   "overrides": {
-    "hono": ">=4.12.18",
+    "hono": "4.12.18",
     "path-to-regexp": ">=8.4.0",
     "picomatch": ">=4.0.4",
     "postcss": ">=8.5.10",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "vitest": "^3.0.0"
   },
   "overrides": {
-    "hono": ">=4.12.18",
+    "hono": "$hono",
     "vite": ">=7.3.2",
     "path-to-regexp": ">=8.4.0",
     "picomatch": ">=4.0.4",

--- a/scripts/run-api-e2e.ts
+++ b/scripts/run-api-e2e.ts
@@ -58,7 +58,7 @@ function applyMigrations(): void {
     const filePath = resolve(MIGRATIONS_DIR, file);
     log(`applying migration: ${file}`);
     execSync(
-      `npx wrangler d1 execute otter-db --local --persist-to=${PERSIST_DIR} --file=${filePath}`,
+      `bunx wrangler d1 execute otter-db --local --persist-to=${PERSIST_DIR} --file=${filePath}`,
       { cwd: WORKER_DIR, stdio: "pipe" },
     );
   }
@@ -72,7 +72,7 @@ function seedTestData(): void {
     "INSERT OR REPLACE INTO _test_marker (key, value) VALUES ('env', 'test');",
   ].join(" ");
   execSync(
-    `npx wrangler d1 execute otter-db --local --persist-to=${PERSIST_DIR} --command="${seedSql}"`,
+    `bunx wrangler d1 execute otter-db --local --persist-to=${PERSIST_DIR} --command="${seedSql}"`,
     { cwd: WORKER_DIR, stdio: "pipe" },
   );
   log("seeded test marker");


### PR DESCRIPTION
Two-layer fix for L2 API E2E failure since 6da171c:

**1. `overrides.hono` semantic mismatch** — root override was `">=4.12.18"` (range) while direct dep is exact `"4.12.18"`; npm 8+ rejects with EOVERRIDE. Switched to `"$hono"` to inherit from the direct dep.

**2. `npx wrangler` against a bun workspace** — `scripts/run-api-e2e.ts` shelled out to npx, which triggered npm dep resolution (failing on the override conflict above + on `workspace:*` protocol that npm doesn't support). Switched to `bunx wrangler` since this is a pure bun workspace and CI is bun.

Either fix alone unblocks CI; both together make the script robust for future override changes.

Pre-commit hooks pass (G1 + L1 + tsc + gitleaks).