### PR TITLE
[🥝 choko] ci(release): bump wrangler-action v3 → v4 for Node 22+

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         run: bun run build
 
       - name: Deploy Worker
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}


### PR DESCRIPTION
Release CD failed: `cloudflare/wrangler-action@v3` runs on Node 20 internally, but wrangler 4.x requires Node ≥22.

Fix: upgrade to `@v4` (uses Node 22).

Reviewed by Reviewer-01 (STU-113) — APPROVE.