### PR TITLE
ci: fix wrangler-action deploy with bun packageManager

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
           workingDirectory: packages/worker
+          packageManager: bun
           command: deploy
 
       - name: Verify deployment


### PR DESCRIPTION
wrangler-action 内部默认用 npm 安装 wrangler，但项目使用 bun。npm 不支持 workspace: 协议和某些 overrides 写法，导致 Deploy Worker step 失败。\n\n修复：添加 packageManager: bun 让 wrangler-action 使用 bun 安装。