### PR TITLE
chore(deps): batch upgrade @cloudflare/workers-types + @types/node

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
         "zod": "^4.3.6",
       },
       "devDependencies": {
-        "@types/node": "^25.9.2",
+        "@types/node": "^25.9.3",
         "typescript": "^6.0.3",
       },
     },
@@ -40,14 +40,14 @@
       },
       "devDependencies": {
         "@otter/core": "workspace:*",
-        "@types/node": "^25.9.2",
+        "@types/node": "^25.9.3",
       },
     },
     "packages/core": {
       "name": "@otter/core",
       "version": "2.0.2",
       "devDependencies": {
-        "@types/node": "^25.3.4",
+        "@types/node": "^25.9.3",
       },
     },
     "packages/web": {
@@ -542,7 +542,7 @@
 
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 
-    "@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
+    "@types/node": ["@types/node@25.9.3", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg=="],
 
     "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -89,7 +89,7 @@
       },
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "0.16.14",
-        "@cloudflare/workers-types": "^4.20260609.1",
+        "@cloudflare/workers-types": "^4.20260610.1",
         "typescript": "^6.0.3",
         "vitest": "^4.1.8",
         "wrangler": "^4.99.0",
@@ -150,7 +150,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260609.1", "", { "os": "win32", "cpu": "x64" }, "sha512-EWhfxKI1aqUr7S8xuGxgmRCumEzB8iSsCIz6oEqJN+3pZuW3EWiKDGFW4EY1BmwNINLW1eO5VMGYb8Fj6FVYxA=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260609.1", "", {}, "sha512-krGHtwSApCFBjTe1NTx/TFQ0P5i/bHGQOqCPnCLssb8rOKaAG4JkPFJZsossr0z/ZTMnpP2Tid5jWju+/i0hCA=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260610.1", "", {}, "sha512-Mk/f3lUygeIHzQ4HnJjU/JvGg/kllgp9gISty9nylHE/2M2MFeKO+hgAKSgiPpmwUbuhewdYGgqFGgT/ADK0/g=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -20,7 +20,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@types/node": "^25.9.2",
+    "@types/node": "^25.9.3",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,6 +37,6 @@
   },
   "devDependencies": {
     "@otter/core": "workspace:*",
-    "@types/node": "^25.9.2"
+    "@types/node": "^25.9.3"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,6 +13,6 @@
     "dist"
   ],
   "devDependencies": {
-    "@types/node": "^25.3.4"
+    "@types/node": "^25.9.3"
   }
 }

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "0.16.14",
-    "@cloudflare/workers-types": "^4.20260609.1",
+    "@cloudflare/workers-types": "^4.20260610.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.8",
     "wrangler": "^4.99.0"


### PR DESCRIPTION
## Summary

- Upgrade `@cloudflare/workers-types` `4.20260609.1` → `4.20260610.1` in `packages/worker`
- Upgrade `@types/node` `25.3.4 / 25.9.2` → `25.9.3` across `packages/api`, `packages/cli`, `packages/core`

Atomic per-package commits, manifests keep caret ranges, `bun.lock` pinned to the targeted patch versions.

Closes (after merge): #55, #56

## Test plan

- [x] G1 Biome lint (pre-commit)
- [x] L1 vitest unit + 96.79% coverage (pre-push)
- [x] tsc strict typecheck (pre-commit)
- [x] L2 wrangler dev miniflare API e2e (pre-push, 14/14)
- [x] G2 osv-scanner + gitleaks (pre-push)