### PR TITLE
chore(deps): bump @cloudflare/workers-types to 4.20260613.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -90,7 +90,7 @@
       },
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "0.16.15",
-        "@cloudflare/workers-types": "4.20260612.1",
+        "@cloudflare/workers-types": "4.20260613.1",
         "typescript": "^6.0.3",
         "vitest": "^4.1.8",
         "wrangler": "^4.100.0",
@@ -152,7 +152,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260611.1", "", { "os": "win32", "cpu": "x64" }, "sha512-S6JkS0kEbcCKs19RGqEPhjCRbP8GBkQwqYLp2fhBJtD/KTlwqLzOJ9E6PQ7gQKgWHtxy1NBG3oXarlNFRNU/dw=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260612.1", "", {}, "sha512-PMQI7XP/wrMhxyjseUHoHj6XFqkHaf4utWQ/hhefVY8oMK2LJ730oeQ7H/nZSVMexZe39DzsdOx7sf1PqMr7+Q=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260613.1", "", {}, "sha512-1mrgjE6epolwBhroeGAp5ud5H6Vyi6tl1o/NP0T4rXJ8bmEjmhHnbCzAhHTDHV0PIeip43wcuzHKJarvaGTaUA=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "0.16.15",
-    "@cloudflare/workers-types": "4.20260612.1",
+    "@cloudflare/workers-types": "4.20260613.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.8",
     "wrangler": "^4.100.0"


### PR DESCRIPTION
## Summary

- Bump `@cloudflare/workers-types` from `4.20260612.1` to `4.20260613.1` in `packages/worker` devDependencies.
- Minor bump generated by `[🥝 choko][deps]` autopilot.

Closes #70

## Test plan

- [x] `bun run --cwd packages/worker test` — 4 files / 22 tests pass
- [x] pre-commit hook: lint + unit tests + tsc + gitleaks all green
- [x] pre-push hook: osv-scanner + gitleaks history + L1 coverage + L2 API e2e all green