### PR TITLE
fix(api): make CF Access JWT middleware fail-closed (#86)

### DIFF
--- a/packages/api/src/__tests__/unit/access-auth.test.ts
+++ b/packages/api/src/__tests__/unit/access-auth.test.ts
@@ -60,14 +60,73 @@ describe("accessAuth", () => {
     expect(json.auth).toBe(false);
   });
 
-  it("falls through when env vars missing", async () => {
+  it("returns 500 when env vars missing (fail-closed)", async () => {
     const app = makeApp();
     const r = await app.fetch(
       new Request("https://prod.example.com/api/me", {
         headers: { host: "prod.example.com" },
       }),
     );
+    expect(r.status).toBe(500);
+    const json = (await r.json()) as { error: string };
+    expect(json.error).toMatch(/not configured/i);
+  });
+
+  it("returns 500 when only CF_ACCESS_TEAM_DOMAIN set (missing AUD)", async () => {
+    const app = makeApp({ CF_ACCESS_TEAM_DOMAIN: "team.cloudflareaccess.com" });
+    const r = await app.fetch(
+      new Request("https://prod.example.com/api/me", {
+        headers: { host: "prod.example.com", "Cf-Access-Jwt-Assertion": "jwt" },
+      }),
+    );
+    expect(r.status).toBe(500);
+  });
+
+  it("returns 500 when c.env is undefined (fail-closed)", async () => {
+    const app = new Hono<AppEnv>();
+    app.use("*", accessAuth);
+    app.get("/api/me", (c) =>
+      c.json({
+        auth: c.get("accessAuthenticated") ?? false,
+      }),
+    );
+    // Call fetch with no env argument so c.env is undefined
+    const r = await app.fetch(
+      new Request("https://prod.example.com/api/me", {
+        headers: { host: "prod.example.com", "Cf-Access-Jwt-Assertion": "jwt" },
+      }),
+    );
+    expect(r.status).toBe(500);
+  });
+
+  it("returns 401 when no Cf-Access-Jwt-Assertion header on edge (fail-closed)", async () => {
+    const app = makeApp({
+      CF_ACCESS_TEAM_DOMAIN: "team.cloudflareaccess.com",
+      CF_ACCESS_AUD: "aud-123",
+    });
+    const r = await app.fetch(
+      new Request("https://prod.example.com/api/me", {
+        headers: { host: "prod.example.com" },
+      }),
+    );
+    expect(r.status).toBe(401);
+    const json = (await r.json()) as { error: string };
+    expect(json.error).toMatch(/missing access jwt/i);
+  });
+
+  it("falls through to apiKeyAuth when no JWT but Bearer header present (CLI/surety)", async () => {
+    const app = makeApp({
+      CF_ACCESS_TEAM_DOMAIN: "team.cloudflareaccess.com",
+      CF_ACCESS_AUD: "aud-123",
+    });
+    const r = await app.fetch(
+      new Request("https://otter.workers.dev/api/me", {
+        headers: { host: "otter.workers.dev", Authorization: "Bearer otk_xx" },
+      }),
+    );
     const json = (await r.json()) as { auth: boolean };
+    // accessAuth must NOT stamp accessAuthenticated; apiKeyAuth (not mounted here)
+    // is responsible for verifying the Bearer token.
     expect(json.auth).toBe(false);
   });
 
@@ -94,7 +153,7 @@ describe("accessAuth", () => {
     });
   });
 
-  it("falls through when JWT verification throws", async () => {
+  it("returns 403 when JWT verification throws (fail-closed)", async () => {
     verifyMock.mockRejectedValueOnce(new Error("bad sig"));
     const app = makeApp({
       CF_ACCESS_TEAM_DOMAIN: "team.cloudflareaccess.com",
@@ -105,51 +164,9 @@ describe("accessAuth", () => {
         headers: { host: "prod.example.com", "Cf-Access-Jwt-Assertion": "bad" },
       }),
     );
-    const json = (await r.json()) as { auth: boolean };
-    expect(json.auth).toBe(false);
-  });
-
-  it("falls through when only CF_ACCESS_TEAM_DOMAIN set (missing AUD)", async () => {
-    const app = makeApp({ CF_ACCESS_TEAM_DOMAIN: "team.cloudflareaccess.com" });
-    const r = await app.fetch(
-      new Request("https://prod.example.com/api/me", {
-        headers: { host: "prod.example.com", "Cf-Access-Jwt-Assertion": "jwt" },
-      }),
-    );
-    const json = (await r.json()) as { auth: boolean };
-    expect(json.auth).toBe(false);
-  });
-
-  it("falls through when no Cf-Access-Jwt-Assertion header on edge", async () => {
-    const app = makeApp({
-      CF_ACCESS_TEAM_DOMAIN: "team.cloudflareaccess.com",
-      CF_ACCESS_AUD: "aud-123",
-    });
-    const r = await app.fetch(
-      new Request("https://prod.example.com/api/me", {
-        headers: { host: "prod.example.com" },
-      }),
-    );
-    const json = (await r.json()) as { auth: boolean };
-    expect(json.auth).toBe(false);
-  });
-
-  it("falls through when c.env is undefined (Hono fetch without env arg)", async () => {
-    const app = new Hono<AppEnv>();
-    app.use("*", accessAuth);
-    app.get("/api/me", (c) =>
-      c.json({
-        auth: c.get("accessAuthenticated") ?? false,
-      }),
-    );
-    // Call fetch with no env argument so c.env is undefined
-    const r = await app.fetch(
-      new Request("https://prod.example.com/api/me", {
-        headers: { host: "prod.example.com", "Cf-Access-Jwt-Assertion": "jwt" },
-      }),
-    );
-    const json = (await r.json()) as { auth: boolean };
-    expect(json.auth).toBe(false);
+    expect(r.status).toBe(403);
+    const json = (await r.json()) as { error: string };
+    expect(json.error).toMatch(/invalid access jwt/i);
   });
 
   it("E2E_SKIP_AUTH bypasses auth outside production", async () => {
@@ -185,14 +202,16 @@ describe("accessAuth", () => {
       ENVIRONMENT: "production",
       E2E_SKIP_AUTH: "true",
       DEV_USER_EMAIL: "e2e@test.local",
+      CF_ACCESS_TEAM_DOMAIN: "team.cloudflareaccess.com",
+      CF_ACCESS_AUD: "aud-123",
     });
     const r = await app.fetch(
       new Request("https://otter.hexly.ai/api/me", {
         headers: { host: "otter.hexly.ai" },
       }),
     );
-    const json = (await r.json()) as { auth: boolean };
-    expect(json.auth).toBe(false);
+    // No JWT header → fail-closed 401
+    expect(r.status).toBe(401);
   });
 
   it("E2E_SKIP_AUTH with Bearer header does not auto-stamp (lets apiKeyAuth verify)", async () => {

--- a/packages/api/src/middleware/access-auth.ts
+++ b/packages/api/src/middleware/access-auth.ts
@@ -1,9 +1,20 @@
-// access-auth — Cloudflare Access JWT verification.
+// access-auth — Cloudflare Access JWT verification (fail-closed).
 //
-// Verifies `Cf-Access-Jwt-Assertion` against CF Access JWKS. On success,
-// sets `accessAuthenticated`/`accessEmail` on the Hono context. Falls
-// through (does NOT 401) on missing/invalid token so apiKeyAuth can take a
-// second chance with Bearer tokens.
+// Verifies `Cf-Access-Jwt-Assertion` against CF Access JWGS. On success,
+// sets `accessAuthenticated`/`accessEmail` on the Hono context and falls
+// through to the next middleware (typically apiKeyAuth, which sees the
+// authenticated flag and passes through).
+//
+// Failure modes (after public-path / E2E-bypass / localhost short-circuits):
+//   - env missing (CF_ACCESS_TEAM_DOMAIN / CF_ACCESS_AUD) → 500
+//   - Cf-Access-Jwt-Assertion header missing               → 401
+//   - JWT verification throws                              → 403
+//
+// Fail-CLOSED matters because the workers.dev subdomain is enabled and
+// bypasses CF Access entirely — falling through here would let unauthenticated
+// requests reach apiKeyAuth (and any other downstream that trusts upstream
+// auth). See nocoo/otter#86 for the original report and the bat standard
+// implementation this mirrors.
 import type { Context, Next } from "hono";
 import { createRemoteJWKSet, jwtVerify } from "jose";
 import type { AppBindings, AppEnv } from "../lib/app-env";
@@ -56,10 +67,20 @@ export async function accessAuth(c: Context<AppEnv>, next: Next) {
 
   const teamDomain = env.CF_ACCESS_TEAM_DOMAIN;
   const aud = env.CF_ACCESS_AUD;
-  if (!(teamDomain && aud)) return next();
+  if (!(teamDomain && aud)) {
+    return c.json(
+      {
+        error: "Access authentication not configured. Set CF_ACCESS_TEAM_DOMAIN and CF_ACCESS_AUD.",
+      },
+      500,
+    );
+  }
 
   const jwt = c.req.header("Cf-Access-Jwt-Assertion");
-  if (!jwt) return next();
+  if (!jwt) {
+    if (hasBearer(c)) return next();
+    return c.json({ error: "Missing Access JWT" }, 401);
+  }
 
   try {
     const jwks = getJwks(teamDomain);
@@ -73,7 +94,7 @@ export async function accessAuth(c: Context<AppEnv>, next: Next) {
       c.set("accessEmail", email);
     }
   } catch {
-    // verification failed — let apiKeyAuth try
+    return c.json({ error: "Invalid Access JWT" }, 403);
   }
   return next();
 }

--- a/packages/api/src/middleware/access-auth.ts
+++ b/packages/api/src/middleware/access-auth.ts
@@ -1,6 +1,6 @@
 // access-auth — Cloudflare Access JWT verification (fail-closed).
 //
-// Verifies `Cf-Access-Jwt-Assertion` against CF Access JWGS. On success,
+// Verifies `Cf-Access-Jwt-Assertion` against CF Access JWKS. On success,
 // sets `accessAuthenticated`/`accessEmail` on the Hono context and falls
 // through to the next middleware (typically apiKeyAuth, which sees the
 // authenticated flag and passes through).


### PR DESCRIPTION
# Summary

Make the CF Access JWT middleware **fail-closed** in three previously fail-open paths so the workers.dev subdomain (which bypasses CF Access at the edge) cannot reach downstream middleware with no auth proof.

Before: missing env, missing `Cf-Access-Jwt-Assertion` header, and `jwtVerify()` throws all executed `return next()`. After:

- env missing (`CF_ACCESS_TEAM_DOMAIN` / `CF_ACCESS_AUD`) → **500**
- `Cf-Access-Jwt-Assertion` header missing → **401**
  - Exception: when a `Authorization: Bearer ...` header is also present, fall through to `apiKeyAuth`. This preserves the surety / CLI direct-to-workers.dev path documented in the project retrospective; `accessAuth` deliberately does NOT stamp `accessAuthenticated` here, so `apiKeyAuth` remains the authority on the Bearer token.
- `jwtVerify()` throws → **403**

`PUBLIC_PATHS` (`/api/live`, `/v1/live`), `tryE2eBypass` (`E2E_SKIP_AUTH=true` outside production), and the `isLocalhost` dev bypass are all preserved.

Mirrors the bat reference implementation (`nocoo/bat:packages/worker/src/middleware/access-auth.ts`).

# Test plan

- [x] `bunx vitest run packages/api/src/__tests__/unit/access-auth.test.ts` — 14 cases, covers all 5 acceptance scenarios from #86 plus the no-JWT + Bearer fall-through carve-out
- [x] `bunx vitest run` — 580 pass
- [x] `bun run lint:biome` — 0 errors
- [x] `tsc -b packages/core packages/cli packages/web packages/api` — clean
- [x] Local pre-push gates: `osv-scanner`, `gitleaks --no-banner -v` (full history), L1 coverage (95/94/95/95), L2 wrangler-dev API + CLI e2e — all pass
- [ ] CI green

Closes nocoo/otter#86
