### PR TITLE
chore(deps): bump @cloudflare/workers-types 4.20260620.1 + lint-staged 17.0.8

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
         "@playwright/test": "^1.61.0",
         "@vitest/coverage-v8": "^4.1.9",
         "husky": "^9.1.7",
-        "lint-staged": "^17.0.7",
+        "lint-staged": "17.0.8",
         "typescript": "^6.0.3",
         "vitest": "^4.1.9",
       },
@@ -741,7 +741,7 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
-    "lint-staged": ["lint-staged@17.0.7", "", { "dependencies": { "listr2": "^10.2.1", "picomatch": "^4.0.4", "string-argv": "^0.3.2", "tinyexec": "^1.2.4" }, "optionalDependencies": { "yaml": "^2.9.0" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-JrSobt+tW3rH8IOMi8tDZd3foorM5yPEkLD/V2NxobgHrFfHWGee4MOLVuZeScgxftEwbHrPHIFA/ZL+nUJeuA=="],
+    "lint-staged": ["lint-staged@17.0.8", "", { "dependencies": { "listr2": "^10.2.1", "picomatch": "^4.0.4", "string-argv": "^0.3.2", "tinyexec": "^1.2.4" }, "optionalDependencies": { "yaml": "^2.9.0" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-B2P/d+jVW0UXOQ0MVMLrB/9ydA1P+zz6jYfdrbbEd9ur3S2rcbduFWKiUCC02Sm5hbC8nrm7y24WuYMG54HfxA=="],
 
     "listr2": ["listr2@10.2.1", "", { "dependencies": { "cli-truncate": "^5.2.0", "eventemitter3": "^5.0.4", "log-update": "^6.1.0", "rfdc": "^1.4.1", "wrap-ansi": "^10.0.0" } }, "sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -90,7 +90,7 @@
       },
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "0.16.18",
-        "@cloudflare/workers-types": "4.20260619.1",
+        "@cloudflare/workers-types": "4.20260620.1",
         "typescript": "^6.0.3",
         "vitest": "^4.1.9",
         "wrangler": "^4.103.0",
@@ -153,7 +153,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260617.1", "", { "os": "win32", "cpu": "x64" }, "sha512-rgBV9wQrv0OSKgCTTbhFUFY3sLGNANZ88aqaLvtmEn2gmbFVb1J4PDGochVUdB7NSEp4D/ghHva6/8SZmbONpw=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260619.1", "", {}, "sha512-bprsNzG0DapQPFwU2AvQlQ6FUO7Y4bKWaPBzLNI7nBSqlHsK0P62xx2NaNT6i/htzAgQspKZm1D32y0RxofrRQ=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260620.1", "", {}, "sha512-WB81w9u1bAS7KcekpC7/nYhLpIXAEtgybso7XgGJV8CQKNkNPYcyjvICLdghOlDBi/9Ivk+f7NRckV2Bkq1bDg=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@playwright/test": "^1.61.0",
     "@vitest/coverage-v8": "^4.1.9",
     "husky": "^9.1.7",
-    "lint-staged": "^17.0.7",
+    "lint-staged": "17.0.8",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9"
   },

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "0.16.18",
-    "@cloudflare/workers-types": "4.20260619.1",
+    "@cloudflare/workers-types": "4.20260620.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9",
     "wrangler": "^4.103.0"


### PR DESCRIPTION
## Summary

Weekly dependency bumps from the choko deps autopilot — both patch-level upgrades, no breaking changes.

| Commit | Package | Change |
|---|---|---|
| `bef4376` | `@cloudflare/workers-types` (`packages/worker`, dev) | 4.20260619.1 → 4.20260620.1 (closes #101) |
| `e01f3ea` | `lint-staged` (root, dev) | 17.0.7 → 17.0.8 (closes #102) |

Atomic commits — one dep per commit — with only `package.json` + `bun.lock` touched per commit. Lockfile regenerated via `bun add -d`.

## Test plan

Local pre-commit + pre-push gates passed:

- [x] `bun run test` — 47 files / 580 tests
- [x] `bun run test:coverage` — 96.8 / 94.16 / 94.37 / 97.05 (statements / branches / functions / lines)
- [x] `bun run typecheck` (`scripts/typecheck-parallel.sh`)
- [x] `bun run lint:biome` — only existing 23 infos (no errors/warnings)
- [x] `bun run build` (web SPA)
- [x] `bun run test:l2` — 3 files / 14 tests (wrangler dev --local + miniflare D1)
- [x] G2: osv-scanner + gitleaks full-history clean

Reviewer-03 APPROVED.
