### PR TITLE
chore(deps): bump @cloudflare/workers-types from 4.20260620.1 to 4.20260621.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -90,7 +90,7 @@
       },
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "0.16.18",
-        "@cloudflare/workers-types": "4.20260620.1",
+        "@cloudflare/workers-types": "4.20260621.1",
         "typescript": "^6.0.3",
         "vitest": "^4.1.9",
         "wrangler": "^4.103.0",
@@ -153,7 +153,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260617.1", "", { "os": "win32", "cpu": "x64" }, "sha512-rgBV9wQrv0OSKgCTTbhFUFY3sLGNANZ88aqaLvtmEn2gmbFVb1J4PDGochVUdB7NSEp4D/ghHva6/8SZmbONpw=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260620.1", "", {}, "sha512-WB81w9u1bAS7KcekpC7/nYhLpIXAEtgybso7XgGJV8CQKNkNPYcyjvICLdghOlDBi/9Ivk+f7NRckV2Bkq1bDg=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260621.1", "", {}, "sha512-c4xrf4shZdDOK1ihh1UKzlS/3MDYiGThT/Oqr4Y3qR9NLCSNzHB7rt+Vk/LOp0ZSNjA+7WNJEQsOhpiQtpT2GA=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "0.16.18",
-    "@cloudflare/workers-types": "4.20260620.1",
+    "@cloudflare/workers-types": "4.20260621.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9",
     "wrangler": "^4.103.0"


### PR DESCRIPTION
## Summary

Bumps `@cloudflare/workers-types` from `4.20260620.1` to `4.20260621.1` in `packages/worker` (devDependencies, minor version).

Closes nocoo/otter#104

## Verification

- ✅ `bun run typecheck` (pre-existing `cloudflare:test` errors are unrelated to this bump — same errors exist on `main`)
- ✅ `bun run test` (worker unit, 22 passed)
- ✅ Pre-commit (G1 + L1 + tsc + gitleaks)
- ✅ Pre-push (G2 osv + gitleaks + L1 coverage + L2 api e2e)
