### PR TITLE
chore(deps): bump swr from 2.3.3 to 2.4.2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -65,7 +65,7 @@
         "react-router": "8.0.1",
         "recharts": "^3.8.1",
         "shiki": "^4.2.0",
-        "swr": "^2.3.3",
+        "swr": "^2.4.2",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
       },
@@ -867,7 +867,7 @@
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
-    "swr": ["swr@2.4.1", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA=="],
+    "swr": ["swr@2.4.2", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw=="],
 
     "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -21,7 +21,7 @@
     "react-router": "8.0.1",
     "recharts": "^3.8.1",
     "shiki": "^4.2.0",
-    "swr": "^2.3.3",
+    "swr": "^2.4.2",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"
   },


### PR DESCRIPTION
## Summary

Bump `swr` from `2.3.3` to `2.4.2` in `packages/web` (minor).

Closes #106

## Changes

- `packages/web/package.json`: `^2.3.3` → `^2.4.2`
- `bun.lock`: resolved `swr@2.4.1` → `swr@2.4.2` (peer deps, license, transitive deps unchanged)

No source-code changes — current usages are default `useSWR`, `SWRConfiguration`, and `mutate()` (`api.ts`, `sidebar.tsx`, `SettingsPage.tsx`), all API-compatible.

## Checks (local)

- Biome lint: ✅
- Vitest: ✅ 47 files / 580 passed
- tsc parallel typecheck: ✅
- Build: ✅
- osv-scanner / gitleaks: ✅
- L2 wrangler API e2e: ✅
- `bun audit`: ✅
